### PR TITLE
Fix missing division in epilogue-X files, regen ToC

### DIFF
--- a/src/epub/text/epilogue-1.xhtml
+++ b/src/epub/text/epilogue-1.xhtml
@@ -6,14 +6,16 @@
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
 	<body epub:type="bodymatter z3998:fiction">
-		<section id="epilogue-1" epub:type="part">
-			<hgroup>
-				<h2>
-					<span epub:type="ordinal">First</span>
-					<span epub:type="label">Epilogue</span>
-				</h2>
-				<h3 epub:type="title">1813⁠–⁠20</h3>
-			</hgroup>
+		<section id="epilogue" epub:type="division">
+			<section id="epilogue-1" epub:type="part">
+				<hgroup>
+					<h3>
+						<span epub:type="ordinal">First</span>
+						<span epub:type="label">Epilogue</span>
+					</h3>
+					<h4 epub:type="title">1813⁠–⁠20</h4>
+				</hgroup>
+			</section
 		</section>
 	</body>
 </html>

--- a/src/epub/text/epilogue-2.xhtml
+++ b/src/epub/text/epilogue-2.xhtml
@@ -6,11 +6,13 @@
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
 	<body epub:type="bodymatter z3998:fiction">
-		<section id="epilogue-2" epub:type="part">
-			<h2>
-				<span epub:type="ordinal">Second</span>
-				<span epub:type="label">Epilogue</span>
-			</h2>
+		<section id="epilogue" epub:type="division">
+			<section id="epilogue-2" epub:type="part">
+				<h3>
+					<span epub:type="ordinal">Second</span>
+					<span epub:type="label">Epilogue</span>
+				</h3>
+			</section>
 		</section>
 	</body>
 </html>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -1124,100 +1124,102 @@
 						</li>
 						<li>
 							<a href="text/epilogue.xhtml">Epilogue</a>
-						</li>
-						<li>
-							<a href="text/epilogue-1.xhtml">First Epilogue: 1813–20</a>
 							<ol>
 								<li>
-									<a href="text/epilogue-1-1.xhtml" epub:type="z3998:roman">I</a>
+									<a href="text/epilogue-1.xhtml">First Epilogue: 1813–20</a>
+									<ol>
+										<li>
+											<a href="text/epilogue-1-1.xhtml" epub:type="z3998:roman">I</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-2.xhtml" epub:type="z3998:roman">II</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-3.xhtml" epub:type="z3998:roman">III</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-4.xhtml" epub:type="z3998:roman">IV</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-5.xhtml" epub:type="z3998:roman">V</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-6.xhtml" epub:type="z3998:roman">VI</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-7.xhtml" epub:type="z3998:roman">VII</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-8.xhtml" epub:type="z3998:roman">VIII</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-9.xhtml" epub:type="z3998:roman">IX</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-10.xhtml" epub:type="z3998:roman">X</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-11.xhtml" epub:type="z3998:roman">XI</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-12.xhtml" epub:type="z3998:roman">XII</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-13.xhtml" epub:type="z3998:roman">XIII</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-14.xhtml" epub:type="z3998:roman">XIV</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-15.xhtml" epub:type="z3998:roman">XV</a>
+										</li>
+										<li>
+											<a href="text/epilogue-1-16.xhtml" epub:type="z3998:roman">XVI</a>
+										</li>
+									</ol>
 								</li>
 								<li>
-									<a href="text/epilogue-1-2.xhtml" epub:type="z3998:roman">II</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-3.xhtml" epub:type="z3998:roman">III</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-4.xhtml" epub:type="z3998:roman">IV</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-5.xhtml" epub:type="z3998:roman">V</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-6.xhtml" epub:type="z3998:roman">VI</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-7.xhtml" epub:type="z3998:roman">VII</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-8.xhtml" epub:type="z3998:roman">VIII</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-9.xhtml" epub:type="z3998:roman">IX</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-10.xhtml" epub:type="z3998:roman">X</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-11.xhtml" epub:type="z3998:roman">XI</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-12.xhtml" epub:type="z3998:roman">XII</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-13.xhtml" epub:type="z3998:roman">XIII</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-14.xhtml" epub:type="z3998:roman">XIV</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-15.xhtml" epub:type="z3998:roman">XV</a>
-								</li>
-								<li>
-									<a href="text/epilogue-1-16.xhtml" epub:type="z3998:roman">XVI</a>
+									<a href="text/epilogue-2.xhtml">Second Epilogue</a>
+									<ol>
+										<li>
+											<a href="text/epilogue-2-1.xhtml" epub:type="z3998:roman">I</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-2.xhtml" epub:type="z3998:roman">II</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-3.xhtml" epub:type="z3998:roman">III</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-4.xhtml" epub:type="z3998:roman">IV</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-5.xhtml" epub:type="z3998:roman">V</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-6.xhtml" epub:type="z3998:roman">VI</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-7.xhtml" epub:type="z3998:roman">VII</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-8.xhtml" epub:type="z3998:roman">VIII</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-9.xhtml" epub:type="z3998:roman">IX</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-10.xhtml" epub:type="z3998:roman">X</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-11.xhtml" epub:type="z3998:roman">XI</a>
+										</li>
+										<li>
+											<a href="text/epilogue-2-12.xhtml" epub:type="z3998:roman">XII</a>
+										</li>
+									</ol>
 								</li>
 							</ol>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/epilogue-2.xhtml">Second Epilogue</a>
-					<ol>
-						<li>
-							<a href="text/epilogue-2-1.xhtml" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-2.xhtml" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-3.xhtml" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-4.xhtml" epub:type="z3998:roman">IV</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-5.xhtml" epub:type="z3998:roman">V</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-6.xhtml" epub:type="z3998:roman">VI</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-7.xhtml" epub:type="z3998:roman">VII</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-8.xhtml" epub:type="z3998:roman">VIII</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-9.xhtml" epub:type="z3998:roman">IX</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-10.xhtml" epub:type="z3998:roman">X</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-11.xhtml" epub:type="z3998:roman">XI</a>
-						</li>
-						<li>
-							<a href="text/epilogue-2-12.xhtml" epub:type="z3998:roman">XII</a>
 						</li>
 					</ol>
 				</li>


### PR DESCRIPTION
The epilogue-X.xhtml files were missing the division sections, and were the wrong level (h2 instead of h3).